### PR TITLE
disables preview during clash

### DIFF
--- a/CluckCluckMoose/source/CCMGameScene.cpp
+++ b/CluckCluckMoose/source/CCMGameScene.cpp
@@ -302,7 +302,7 @@ void GameScene::update(float timestep) {
 		//CULog("SKIP: %d",skipState);
 	}
 
-	if (sb->getPreview() && !isPreviewing) { //replace with if Preview button is pressed
+	if (sb->getPreview() && !isPreviewing && !isClashing) { //replace with if Preview button is pressed
 		//Play the button sfx
 		string sfx = rand() % 2 ? SOUND_BUTTON_A : SOUND_BUTTON_B;
 		auto source = _assets->get<Sound>(sfx);


### PR DESCRIPTION
Fixes crash due to preview attempt after clash.
Button can still be pressed, but preview will not be attempted.