### PR TITLE
fixed pause menu deactivation issues

### DIFF
--- a/CluckCluckMoose/source/CCMApp.cpp
+++ b/CluckCluckMoose/source/CCMApp.cpp
@@ -212,6 +212,7 @@ void CCMApp::update(float timestep) {
 		//CULog("done updating input");
         if (_current == 0) { // if on menu scene
             if (_menuscene.getPlay()) { // play is clicked
+                _menuscene.deactivateButtons();
                 _gameplay[_current]->setActive(false);
                 _current = 1; // to level select
                 _gameplay[_current]->setActive(true);
@@ -231,7 +232,7 @@ void CCMApp::update(float timestep) {
                 _levelscene.deactivateButtons();
                 _gameplay[_current]->setActive(false);
                 _current = 2;
-
+                
 				//load level, if able
 				stringstream ss;
 				ss << "json/level" << _levelscene.getLevel() << ".json";
@@ -296,6 +297,7 @@ void CCMApp::update(float timestep) {
 					}
 				}
                 _gameplay[_current]->setActive(true);
+                _gamescene->deactivatePause();
             }
         }
         else if (_current == 2) { // in game scene
@@ -304,11 +306,13 @@ void CCMApp::update(float timestep) {
 				_saveLoad.saveLevel(_gamescene->getPlayer(), _gamescene->getOpp(), _gamescene->getAI(), _levelscene.getLevel());
 				lastLevel = _levelscene.getLevel();
                 _gamescene->setHome(false);
+                _gamescene->deactivatePause();
                 _gameplay[_current]->setActive(false);
                 //_gameplay[_current]->dispose();
                 //_gameplay.erase(_gameplay.begin()+_current);
                 _current = 0; // back to main menu
                 _gameplay[_current]->setActive(true);
+                _menuscene.activateButtons();
                 _levelscene.setLevel(0);
             }
         }

--- a/CluckCluckMoose/source/CCMGameScene.h
+++ b/CluckCluckMoose/source/CCMGameScene.h
@@ -151,9 +151,13 @@ public:
 	 */
 	void setAI(std::shared_ptr<Moose> newPlayer, std::shared_ptr<Moose> newOpp, AIType newAI) { oppAI->setPlayer(newPlayer); oppAI->setOpp(newOpp); oppAI->setType(newAI); };
 
-	void setHome(bool val) { sb->setHome(val); }
+    void setHome(bool val) { sb->setHome(val); };
 
 	void setLevel(int levelNum) { sb->setLevelNum(levelNum); };
+    
+    void deactivatePause() {sb->deactivatePause(); };
+    
+    void activatePause() {sb->activatePause(); };
 
 #pragma mark -
 #pragma mark Gameplay Handling

--- a/CluckCluckMoose/source/CCMMenuScene.cpp
+++ b/CluckCluckMoose/source/CCMMenuScene.cpp
@@ -45,6 +45,9 @@ std::shared_ptr<Node> menubuttonCanvas;
 // List for credits buttons
 std::vector<std::shared_ptr<Button>> creditsbuttons;
 
+// List for non-credits buttons
+std::vector<std::shared_ptr<Button>> menubuttons;
+
 
 //Preview tracking
 bool playClicked;
@@ -200,8 +203,11 @@ bool MenuScene::init(const std::shared_ptr<AssetManager>& assets) {
 
     //ensure keys are unique
     playbutt->activate(100);
+    menubuttons.push_back(playbutt); // 0
     helpbutt->activate(101);
+    menubuttons.push_back(helpbutt); // 1
     creditsbutt->activate(102);
+    menubuttons.push_back(creditsbutt); // 2
     
     std::shared_ptr<Texture> creditsbg = _assets->get<Texture>("levelbg");
     std::shared_ptr<PolygonNode> creditbackground = PolygonNode::allocWithTexture(creditsbg);
@@ -257,11 +263,13 @@ void MenuScene::update(float timestep) {
     }
     if (creditsClicked){
         creditsClicked = false;
+        deactivateButtons();
         creditsCanvas->setVisible(true);
         creditsbuttons[0]->activate(103);
     }
-    if (creditsBackClicked){
+    else if (creditsBackClicked){
         creditsBackClicked = false;
+        activateButtons();
         creditsCanvas->setVisible(false);
         creditsbuttons[0]->deactivate();
     }
@@ -291,6 +299,20 @@ void MenuScene::playButtonSound() {
 	if (!AudioChannels::get()->isActiveEffect(SOUND_BUTTON_A) && !AudioChannels::get()->isActiveEffect(SOUND_BUTTON_B)) {
 		AudioChannels::get()->playEffect(sfx, source, false, source->getVolume());
 	}
+}
+
+void MenuScene::activateButtons() {
+//    pauseMenuCanvas->setVisible(true);
+    for (int i = 0; i < menubuttons.size(); i++) {
+        menubuttons[i]->activate(100 + i);
+    }
+}
+
+void MenuScene::deactivateButtons() {
+//    pauseMenuCanvas->setVisible(false);
+    for (int i = 0; i < menubuttons.size(); i++) {
+        menubuttons[i]->deactivate();
+    }
 }
 
 bool MenuScene::getPlay() { return playClicked; }

--- a/CluckCluckMoose/source/CCMMenuScene.h
+++ b/CluckCluckMoose/source/CCMMenuScene.h
@@ -86,6 +86,8 @@ public:
      */
     bool getPlay();
     void setPlay(bool val);
+    void activateButtons();
+    void deactivateButtons();
     cugl::Size computeActiveSize() const;
 };
 

--- a/CluckCluckMoose/source/SceneBuilder1.cpp
+++ b/CluckCluckMoose/source/SceneBuilder1.cpp
@@ -947,8 +947,9 @@ bool SceneBuilder1::init(const std::shared_ptr<cugl::AssetManager>& assets, cons
     pauseResume->setAnchor(Vec2::ANCHOR_CENTER);
     pauseResume->setPosition(screenWidth/2, screenHeight/2 - INFO_Y_OFFSET);
     pauseResume->setListener([=](const std::string& name, bool down) { if (down) {
-        pauseMenuCanvas->setVisible(false);
+//        pauseMenuCanvas->setVisible(false);
         isPaused = false;
+        CULog("resume pressed");
     }});
     pauseMenuCanvas->addChild(pauseResume);
     pauseResume->activate(203); //ensure keys are unique
@@ -969,8 +970,7 @@ bool SceneBuilder1::init(const std::shared_ptr<cugl::AssetManager>& assets, cons
     pauseSettings->activate(204); //ensure keys are unique
     pausebuttons.push_back(pauseSettings); // 3
 
-    pauseMenuCanvas->setVisible(false);
-
+//    pauseMenuCanvas->setVisible(false);
 	deactivatePause();
 
 	//Initialize distribution
@@ -2036,6 +2036,13 @@ void SceneBuilder1::setOppCost(string costume) {
 	moose2->setPosition(screenWidth + MOOSE_X_OFFSET, MOOSE_HEIGHT);
 	moose2->flipHorizontal(true);
 	mooseCanvas->addChildWithName(moose2, "opp_moose");
+    
+    if (retry or goHome or nextLevel or !isPaused) { deactivatePause(); }
+    
+    if (retry or goHome){
+        isPaused = false;
+        //        deactivatePause();
+    }
 }
 
 void SceneBuilder1::deactivateHand() {
@@ -2061,12 +2068,14 @@ void SceneBuilder1::activateHand() {
 }
 
 void SceneBuilder1::activatePause() {
+    pauseMenuCanvas->setVisible(true);
 	for (int i = 0; i < 4; i++) {
 		pausebuttons[i]->activate(201 + i);
 	}
 }
 
 void SceneBuilder1::deactivatePause() {
+    pauseMenuCanvas->setVisible(false);
 	for (int i = 0; i < 4; i++) {
 		pausebuttons[i]->deactivate();
 	}

--- a/CluckCluckMoose/source/SceneBuilder1.cpp
+++ b/CluckCluckMoose/source/SceneBuilder1.cpp
@@ -946,11 +946,7 @@ bool SceneBuilder1::init(const std::shared_ptr<cugl::AssetManager>& assets, cons
     pauseResume->setScale(0.65, 0.65);
     pauseResume->setAnchor(Vec2::ANCHOR_CENTER);
     pauseResume->setPosition(screenWidth/2, screenHeight/2 - INFO_Y_OFFSET);
-    pauseResume->setListener([=](const std::string& name, bool down) { if (down) {
-//        pauseMenuCanvas->setVisible(false);
-        isPaused = false;
-        CULog("resume pressed");
-    }});
+    pauseResume->setListener([=](const std::string& name, bool down) { if (down) { isPaused = false; }});
     pauseMenuCanvas->addChild(pauseResume);
     pauseResume->activate(203); //ensure keys are unique
     pausebuttons.push_back(pauseResume); // 2
@@ -1013,6 +1009,8 @@ bool SceneBuilder1::init(const std::shared_ptr<cugl::AssetManager>& assets, cons
     sign->setPosition(screenWidth/2, healthYScale - 150);
     clashSignCanvas->addChild(sign);
     clashSignCanvas->setVisible(false);
+    
+    deactivatePause();
 
 	return true;
 }
@@ -1051,7 +1049,7 @@ void SceneBuilder1::updateGameScene(float timestep, bool isClashing) {
     if (isPaused && !pausebuttons[0]->isActive()){ activatePause(); }
     else if (!isPaused && pausebuttons[0]->isActive()){ deactivatePause(); }
     
-    if (!soundChanged){
+    if (!soundChanged && isPaused){
         pausebuttons[3]->deactivate();
         pausebuttons.pop_back();
         std::shared_ptr<Texture> texturePauseSettings;
@@ -2039,10 +2037,9 @@ void SceneBuilder1::setOppCost(string costume) {
     
     if (retry or goHome or nextLevel or !isPaused) { deactivatePause(); }
     
-    if (retry or goHome){
-        isPaused = false;
-        //        deactivatePause();
-    }
+//    if (retry or goHome){
+//        isPaused = false;
+//    }
 }
 
 void SceneBuilder1::deactivateHand() {
@@ -2079,6 +2076,7 @@ void SceneBuilder1::deactivatePause() {
 	for (int i = 0; i < 4; i++) {
 		pausebuttons[i]->deactivate();
 	}
+    isPaused = false;
 }
 
 bool SceneBuilder1::getHome() {


### PR DESCRIPTION
- deactivates menu buttons in credits page
- deactivates pause menu buttons in all scenes
- fixed issue where sound toggle was still active without pause menu
- going gamescene->levelselect->gamescene no longer starts with pause menu

@XalkXolc sorry, i had started the menu scene button deactivation before your PR and didn't realize it. hopefully not too much overlap here